### PR TITLE
New features and bug fix

### DIFF
--- a/spoofy/album.py
+++ b/spoofy/album.py
@@ -55,10 +55,13 @@ class Album(Object, ExternalURLMixin, TrackMixin, ImageMixin, ArtistMixin):
 		if self.release_date_precision is None:
 			self.release_date = None
 		else:
-			self.release_date = datetime.strptime(
-				data.pop('release_date'),
-				self.__date_fmt[self.release_date_precision]
-			)
+			try:
+				self.release_date = datetime.strptime(
+					data.pop('release_date'),
+					self.__date_fmt[self.release_date_precision]
+				)
+			except ValueError:
+				self.release_date = None
 
 		self._fill_external_urls(data.pop('external_urls'))
 		self._fill_artists(data.pop('artists'))

--- a/spoofy/client.py
+++ b/spoofy/client.py
@@ -12,7 +12,7 @@ from .device import Device
 from .playing import CurrentlyPlaying, CurrentlyPlayingContext
 from .audiofeatures import AudioFeatures
 
-from .pager import Pager, SearchPager
+from .pager import Pager, SearchPager, CursorBasedPaging
 from .exceptions import SpoofyException, NotFound
 from .utils import SliceIterator
 
@@ -26,9 +26,9 @@ log = logging.getLogger(__name__)
 class Client:
 	'''
 	Client interface for the API.
-	
+
 	This is the class you should be interfacing with when fetching Spotify objects.
-	
+
 	auth: :class:`OAuth`
 		OAuth instance used for authenticating with the API.
 	session: `aiohttp.ClientSession <http://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession>`_
@@ -59,12 +59,18 @@ class Client:
 	def __init__(self, auth):
 		'''
 		Creates a Spotify Client instance.
-		
+
 		:param auth: Instance of :class:`OAuth`
 		'''
 
 		self.auth = auth
 		self.http = HTTP(auth)
+
+	async def __aenter__(self):
+		return self
+
+	async def __aexit__(self, exc_type, exc_val, exc_tb):
+		await self.close_session()
 
 	def _get_id(self, obj):
 		if isinstance(obj, Object):
@@ -78,19 +84,20 @@ class Client:
 		log.info('Refreshing tokens')
 		self.auth.refresh()
 
-	async def get_player(self):
+	async def get_player(self, **kwargs):
 		'''
 		Get a context for what user is currently playing.
 
+		:param kwargs: query params for this request
 		:return: :class:`PlayingContext`
 		'''
 
-		data = await self.http.get_player()
+		data = await self.http.get_player(**kwargs)
 
 		return CurrentlyPlayingContext(self, data)
 
-	async def player_currently_playing(self):
-		data = await self.http.player_currently_playing()
+	async def player_currently_playing(self, **kwargs):
+		data = await self.http.player_currently_playing(**kwargs)
 
 		return CurrentlyPlaying(self, data)
 
@@ -128,14 +135,17 @@ class Client:
 
 		await self.http.player_prev(device_id=self._get_id(device))
 
-	async def player_play(self, device=None):
+	async def player_play(self, device=None, **kwargs):
 		'''
 		Start playback on device.
 
 		:param device: :class:`Device` or Spotify ID.
+		:param kwargs: body params of the request. For example:
+		player_play(context_uri='spotify:album:6xKK037rfCf2f6gf30SpvL',
+					offset=dict(uri='spotify:track:2beor6qrB0XJxW1CM6X9x2'), position_ms=98500)
 		'''
 
-		await self.http.player_play(device_id=self._get_id(device))
+		await self.http.player_play(device_id=self._get_id(device), **kwargs)
 
 	async def player_pause(self, device=None):
 		'''
@@ -188,13 +198,14 @@ class Client:
 
 		await self.http.player_shuffle(state, self._get_id(device))
 
-	async def search(self, *types, q, limit=10):
+	async def search(self, *types, q, limit=10, **kwargs):
 		'''
 		Searches for tracks, artists, albums and/or playlists.
-		
+
 		:param types: The strings 'tracks', 'artists', 'albums' and/or 'playlist' - or you can pass the class equivalents.
 		:param str q: The search query. See Spotifys query construction guide `here. <https://developer.spotify.com/documentation/web-api/reference/search/search/>`_
 		:param int limit: How many results of each type to return.
+		:param kwargs: other query params for this method
 		:return: A dict with a key for each type, whose values are a list of instances.
 		'''
 
@@ -210,7 +221,7 @@ class Client:
 			else:
 				raise SpoofyException('Unknown type.')
 
-		data = await self.http.search(finished_types, q, limit=limit if limit < 50 else 50)
+		data = await self.http.search(finished_types, q, limit=limit if limit < 50 else 50, **kwargs)
 
 		results = {}
 		for tpe in finished_types:
@@ -234,7 +245,7 @@ class Client:
 	async def search_tracks(self, q=None, limit=20):
 		'''
 		Alias for ``Client.search(spoofy.Track, ...)``
-		
+
 		:return: List[:class:`SimpleTrack`]
 		'''
 
@@ -251,14 +262,14 @@ class Client:
 		results = await self.search(Artist, q=q, limit=limit)
 		return results['artists']
 
-	async def search_albums(self, q=None, limit=20):
+	async def search_albums(self, q=None, limit=20, **kwargs):
 		'''
 		Alias for ``Client.search(spoofy.Album, ...)``
 
 		:return: List[:class:`SimpleAlbum`]
 		'''
 
-		results = await self.search(Album, q=q, limit=limit)
+		results = await self.search(Album, q=q, limit=limit, **kwargs)
 		return results['albums']
 
 	async def search_playlists(self, q=None, limit=20):
@@ -274,7 +285,7 @@ class Client:
 	async def search_track(self, q=None):
 		'''
 		Returns the top track for the query.
-		
+
 		:return: :class:`SimpleTrack` or None
 		'''
 
@@ -310,28 +321,32 @@ class Client:
 	async def get_me(self):
 		'''
 		Gets the current user.
-		
+
 		:return: A :class:`PrivateUser` instance of the current user.
 		'''
 
 		data = await self.http.get_me()
 		return PrivateUser(self, data)
 
-	async def get_me_top_tracks(self, limit=20, offset=0):
+	async def get_me_top_tracks(self, limit=20, offset=0, time_range='medium_term'):
 		'''
 		Gets the top tracks of the current user.
-		
+
 		Requires scope ``user-top-read``.
-		
+
 		:param int limit: How many tracks to return. Maximum is 50.
 		:param int offset: The index of the first result to return.
+		:param str time_range: The time period for which data are selected to form a top. Valid values:
+		- long_term (calculated from several years of data and including all new data as it becomes available),
+		- medium_term (approximately last 6 months),
+		- short_term (approximately last 4 weeks).
 		:return: List[:class:`SimpleTrack`]
 		'''
 
 		if limit > 50:
 			raise SpoofyException('Limit must be less or equal to 50.')
 
-		data = await self.http.get_me_top_tracks(limit=limit, offset=offset)
+		data = await self.http.get_me_top_tracks(limit=limit, offset=offset, time_range=time_range)
 
 		tracks = []
 		for track_obj in data['items']:
@@ -339,19 +354,23 @@ class Client:
 
 		return tracks
 
-	async def get_me_top_artists(self, limit=20, offset=0):
+	async def get_me_top_artists(self, limit=20, offset=0, time_range='medium_term'):
 		'''
 		Get the top artists of the current user.
-		
+
 		:param int limit: How many artists to return. Maximum is 50.
 		:param int offset: The index of the first result to return.
+		:param str time_range: The time period for which data are selected to form a top. Valid values:
+		- long_term (calculated from several years of data and including all new data as it becomes available),
+		- medium_term (approximately last 6 months),
+		- short_term (approximately last 4 weeks).
 		:return: List[:class:`SimpleArtist`]
 		'''
 
 		if limit > 50:
 			raise SpoofyException('Limit must be less or equal to 50.')
 
-		data = await self.http.get_me_top_artists(limit=limit, offset=offset)
+		data = await self.http.get_me_top_artists(limit=limit, offset=offset, time_range=time_range)
 
 		artists = []
 		for artist_obj in data['items']:
@@ -362,7 +381,7 @@ class Client:
 	async def get_user(self, user_id):
 		'''
 		Get a user.
-		
+
 		:param str user_id: Spotify ID of user.
 		:return: A :class:`PublicUser` instance.
 		'''
@@ -377,7 +396,7 @@ class Client:
 	async def create_playlist(self, user, name='Unnamed playlist', description=None, public=False, collaborative=False):
 		'''
 		Create a new playlist.
-		
+
 		:param user: :class:`User` instance or Spotify ID.
 		:param str name: Name of the new playlist.
 		:param str description: Description of the new playlist.
@@ -396,7 +415,7 @@ class Client:
 	async def edit_playlist(self, playlist, name=None, description=None, public=None, collaborative=None):
 		'''
 		Edit a playlist.
-		
+
 		:param playlist: :class:`Playlist` instance or Spotify ID.
 		:param str name: New name of the playlist.
 		:param str description: New description of the playlist.
@@ -440,7 +459,7 @@ class Client:
 	async def get_playlist(self, playlist_id):
 		'''
 		Get a pre-existing playlist.
-		
+
 		:param str playlist_id: Spotify ID of the playlist.
 		:return: :class:`FullPlaylist` instance.
 		'''
@@ -458,7 +477,7 @@ class Client:
 	async def get_playlist_tracks(self, playlist):
 		'''
 		Get tracks from a playlist.
-		
+
 		:param playlist: :class:`Playlist` instance or Spotify ID.
 		:return: List[:class:`PlaylistTrack`]
 		'''
@@ -477,7 +496,7 @@ class Client:
 	async def get_user_playlists(self, user):
 		'''
 		Get a list of attainable playlists a user owns.
-		
+
 		:param user: :class:`User` instance or Spotify ID.
 		:return: List[:class:`SimplePlaylist`]
 		'''
@@ -504,7 +523,7 @@ class Client:
 	async def get_track(self, track_id):
 		'''
 		Get a track.
-		
+
 		:param str track_id: Spotify ID of track.
 		:return: :class:`FullTrack` instance.
 		'''
@@ -519,7 +538,7 @@ class Client:
 	async def get_tracks(self, *track_ids):
 		'''
 		Get several tracks.
-		
+
 		:param str track_ids: List of track Spotify IDs.
 		:return: List[:class:`FullTrack`]
 		'''
@@ -540,7 +559,7 @@ class Client:
 	async def get_audio_features(self, track):
 		'''
 		Get 'Audio Features' of a track.
-		
+
 		:param track: :class:`Track` instance or Spotify ID.
 		:return: :class:`AudioFeatures`
 		'''
@@ -557,7 +576,7 @@ class Client:
 	async def get_artist(self, artist_id):
 		'''
 		Get an artist.
-		
+
 		:param str artist_id: Spotify ID of artist.
 		:return: :class:`FullArtist` instance.
 		'''
@@ -574,17 +593,17 @@ class Client:
 		Get an artist's albums
 		:param str artist_id: Spotify ID of artist.
 		:param int limit: How many albums to return.
-		:param dict **kwargs: Other Spotify API fields
+		:param kwargs: other query params for this method
 		:return: List[:class:`SimpleAlbum`]
 		'''
 		try:
-			data = await self.http.get_artist_albums(artist_id, limit, **kwargs)
+			data = await self.http.get_artist_albums(artist_id, limit=limit if limit < 50 else 50, **kwargs)
 		except NotFound:
 			return None
 
 		albums = []
 
-		async for album_obj in Pager(self.http, data):
+		async for album_obj in Pager(self.http, data, limit):
 			albums.append(SimpleAlbum(self, album_obj))
 
 		return albums
@@ -592,7 +611,7 @@ class Client:
 	async def get_artists(self, *artist_ids):
 		'''
 		Get several artists.
-		
+
 		:param artist_ids: List of artist Spotify IDs.
 		:return: List[:class:`FullArtist`]
 		'''
@@ -647,16 +666,17 @@ class Client:
 
 		return artists
 
-	async def get_album(self, album_id):
+	async def get_album(self, album_id, **kwargs):
 		'''
 		Get an album.
-		
+
 		:param str album_id: Spotify ID of album.
+		:param kwargs: other query params for this method
 		:return: :class:`FullAlbum` instance.
 		'''
 
 		try:
-			data = await self.http.get_album(album_id)
+			data = await self.http.get_album(album_id, **kwargs)
 		except NotFound:
 			return None
 
@@ -665,42 +685,43 @@ class Client:
 
 		return album
 
-	async def get_albums(self, *album_ids):
+	async def get_albums(self, *album_ids, **kwargs):
 		'''
 		Get several albums.
-		
+
 		:param str album_ids: Spotify ID of album.
+		:param kwargs: other query params for this method
 		:return: List[:class:`FullAlbum`]
 		'''
 
-		if len(album_ids) > 20:
-			raise SpoofyException('get_albums album limit is 20.')
-
-		data = await self.http.get_albums(album_ids)
-
+		chunks = [album_ids[x:x + 20] for x in range(0, len(album_ids), 20)]
 		albums = []
 
-		for album_obj in data['albums']:
-			if album_obj is None:
-				albums.append(None)
-			else:
-				album = FullAlbum(self, album_obj)
-				await album._fill_tracks(SimpleTrack, Pager(self.http, album_obj['tracks']))
-				albums.append(album)
+		for chunk in chunks:
+			data = await self.http.get_albums(chunk, **kwargs)
+
+			for album_obj in data['albums']:
+				if album_obj is None:
+					albums.append(None)
+				else:
+					album = FullAlbum(self, album_obj)
+					await album._fill_tracks(SimpleTrack, Pager(self.http, album_obj['tracks']))
+					albums.append(album)
 
 		return albums
 
-	async def get_album_tracks(self, album):
+	async def get_album_tracks(self, album, **kwargs):
 		'''
 		Get tracks from an album.
-		
+
 		:param album: :class:`Album` or Spotify ID of album.
+		:param kwargs: other query params for this method
 		:return: List[:class:`SimpleTrack`]
 		'''
 
 		album = self._get_id(album)
 
-		data = await self.http.get_album_tracks(album)
+		data = await self.http.get_album_tracks(album, **kwargs)
 
 		tracks = []
 
@@ -708,3 +729,40 @@ class Client:
 			tracks.append(SimpleTrack(self, track_obj))
 
 		return tracks
+
+	async def get_followed_artists(self, type='artist', limit=float('inf')):
+		'''
+		Get user's followed artists
+
+		:param str type: The ID type: currently only artist is supported.
+		:param int limit: The maximum number of items to return. Default - infinity
+		:return: list[:class:`SimpleArtist`]
+		'''
+		data = await self.http.get_followed_artists(type=type, limit=limit if limit < 50 else 50)
+
+		artists = []
+
+		if type == 'artist':
+			async for artist_obj in CursorBasedPaging(self.http, data, 'artists', limit):
+				artists.append(SimpleArtist(self, artist_obj))
+		else:
+			raise SpoofyException('Currently only artist is supported.')
+
+		return artists
+
+	async def following(self, type, *ids, **kwargs):
+		'''
+		Follow artists or users
+
+		:param str type: The ID type: either artist or user.
+		:param str ids: Spotify ID of the artist or the user.
+		:param kwargs: other query params for this method
+		'''
+
+		chunks = [ids[x:x + 50] for x in range(0, len(ids), 50)]
+
+		for chunk in chunks:
+			await self.http.following(type=type, ids=chunk, **kwargs)
+
+	async def close_session(self):
+		await self.http.close_session()

--- a/spoofy/client.py
+++ b/spoofy/client.py
@@ -569,6 +569,26 @@ class Client:
 
 		return FullArtist(self, data)
 
+	async def get_artist_albums(self, artist_id, limit=50, **kwargs):
+		'''
+		Get an artist's albums
+		:param str artist_id: Spotify ID of artist.
+		:param int limit: How many albums to return.
+		:param dict **kwargs: Other Spotify API fields
+		:return: List[:class:`SimpleAlbum`]
+		'''
+		try:
+			data = await self.http.get_artist_albums(artist_id, limit, **kwargs)
+		except NotFound:
+			return None
+
+		albums = []
+
+		async for album_obj in Pager(self.http, data):
+			albums.append(SimpleAlbum(self, album_obj))
+
+		return albums
+
 	async def get_artists(self, *artist_ids):
 		'''
 		Get several artists.

--- a/spoofy/http.py
+++ b/spoofy/http.py
@@ -94,11 +94,11 @@ class HTTP:
 		else:
 			raise HTTPException(req, 'Request failed after 5 attempts.')
 
-	async def get_player(self):
-		return await self.request(Request('GET', 'me/player'))
+	async def get_player(self, **kwargs):
+		return await self.request(Request('GET', 'me/player', query=kwargs))
 
-	async def player_currently_playing(self):
-		return await self.request(Request('GET', 'me/player/currently-playing'))
+	async def player_currently_playing(self, **kwargs):
+		return await self.request(Request('GET', 'me/player/currently-playing', query=kwargs))
 
 	async def get_devices(self):
 		return await self.request(Request('GET', 'me/player/devices'))
@@ -109,8 +109,8 @@ class HTTP:
 	async def player_prev(self, device_id):
 		await self.request(Request('POST', 'me/player/previous', query=dict(device=device_id) if device_id else None))
 
-	async def player_play(self, device_id):
-		await self.request(Request('PUT', 'me/player/play', query=dict(device=device_id) if device_id else None))
+	async def player_play(self, device_id, **kwargs):
+		await self.request(Request('PUT', 'me/player/play', query=dict(device=device_id) if device_id else None, json=kwargs))
 
 	async def player_pause(self, device_id):
 		await self.request(Request('PUT', 'me/player/pause', query=dict(device=device_id) if device_id else None))
@@ -140,19 +140,18 @@ class HTTP:
 
 		await self.request(Request('PUT', 'me/player/shuffle', query=query))
 
-
-	async def search(self, types, query, limit):
-		return await self.request(Request('GET', 'search', query=dict(type=','.join(types),
-																	  q=query, limit=limit)))
+	async def search(self, types, query, limit, **kwargs):
+		return await self.request(
+			Request('GET', 'search', query=dict(type=','.join(types), q=query, limit=limit, **kwargs)))
 
 	async def get_me(self):
 		return await self.request(Request('GET', 'me'))
 
-	async def get_me_top_tracks(self, limit=20, offset=0):
-		return await self.request(Request('GET', 'me/top/tracks', query=dict(limit=limit, offset=offset)))
+	async def get_me_top_tracks(self, limit=20, offset=0, time_range='medium_term'):
+		return await self.request(Request('GET', 'me/top/tracks', query=dict(limit=limit, offset=offset, time_range=time_range)))
 
-	async def get_me_top_artists(self, limit=20, offset=0):
-		return await self.request(Request('GET', 'me/top/artists', query=dict(limit=limit, offset=offset)))
+	async def get_me_top_artists(self, limit=20, offset=0, time_range='medium_term'):
+		return await self.request(Request('GET', 'me/top/artists', query=dict(limit=limit, offset=offset, time_range=time_range)))
 
 	async def get_playlist(self, playlist_id):
 		return await self.request(Request('GET', 'playlists', id=playlist_id))
@@ -217,11 +216,20 @@ class HTTP:
 	async def get_artist_related_artists(self, artist_id):
 		return await self.request(Request('GET', 'artists/{}/related-artists'.format(artist_id)))
 
-	async def get_album(self, album_id):
-		return await self.request(Request('GET', 'albums', id=album_id))
+	async def get_album(self, album_id, **kwargs):
+		return await self.request(Request('GET', 'albums', id=album_id, query=kwargs))
 
-	async def get_albums(self, album_ids):
-		return await self.request(Request('GET', 'albums', query=dict(ids=','.join(album_ids))))
+	async def get_albums(self, album_ids, **kwargs):
+		return await self.request(Request('GET', 'albums', query=dict(ids=','.join(album_ids), **kwargs)))
 
-	async def get_album_tracks(self, album_id):
-		return await self.request(Request('GET', 'albums/{}/tracks'.format(album_id), query=dict(limit=50)))
+	async def get_album_tracks(self, album_id, **kwargs):
+		return await self.request(Request('GET', 'albums/{}/tracks'.format(album_id), query=dict(limit=50, **kwargs)))
+
+	async def get_followed_artists(self, type='artist', limit=50):
+		return await self.request(Request('GET', 'me/following', query=dict(limit=limit, type=type)))
+
+	async def following(self, type, ids, **kwargs):
+		await self.request(Request('PUT', 'me/following', query=dict(type=type, ids=','.join(ids), **kwargs)))
+
+	async def close_session(self):
+		await self.session.close()

--- a/spoofy/http.py
+++ b/spoofy/http.py
@@ -205,6 +205,9 @@ class HTTP:
 	async def get_artist(self, artist_id):
 		return await self.request(Request('GET', 'artists', id=artist_id))
 
+	async def get_artist_albums(self, artist_id, limit=50, **kwargs):
+		return await self.request(Request('GET', 'artists/{}/albums'.format(artist_id), query=dict(limit=limit, **kwargs)))
+
 	async def get_artists(self, artist_ids):
 		return await self.request(Request('GET', 'artists', query=dict(ids=','.join(artist_ids))))
 

--- a/spoofy/pager.py
+++ b/spoofy/pager.py
@@ -53,3 +53,11 @@ class SearchPager(Pager):
 	def set_next(self, obj):
 		obj = obj[self.type]
 		super().set_next(obj)
+
+
+class CursorBasedPaging(SearchPager):
+
+	def set_next(self, obj):
+		obj[self.type]['offset'] = None
+		self.cursors = obj[self.type]['cursors']
+		super().set_next(obj)

--- a/spoofy/playing.py
+++ b/spoofy/playing.py
@@ -66,9 +66,16 @@ class CurrentlyPlayingContext(CurrentlyPlaying):
 		'''Goes to the previous track.'''
 		await self._client.player_prev(device=self.device.id)
 
-	async def play(self):
-		'''Starts playback.'''
-		await self._client.player_play(device=self.device.id)
+	async def play(self, **kwargs):
+		'''
+		Starts playback.
+
+		:param kwargs: body Parameters of the request. For example:
+		player_play(context_uri='spotify:album:1Je1IMUlBXcx1Fz0WE7oPT',
+					offset=dict(uri='spotify:track:1301WleyT98MSxVHPZCA6M'), position_ms=1000)
+		'''
+
+		await self._client.player_play(device=self.device.id, **kwargs)
 
 	async def pause(self):
 		'''Pauses playback.'''


### PR DESCRIPTION
### What has been added?

- Method 'get_artist_albums' for [this](https://developer.spotify.com/documentation/web-api/reference/artists/get-artists-albums/) api endpoint
- Few methods for follow management ([this](https://developer.spotify.com/documentation/web-api/reference/follow/follow-artists-users/) and [this](https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/) endpoints)
- Basic "[CursorBasedPaging](https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/)" for "get_followed_artists" method
- Method for close aiohttp session and context manager for this
Example: 
```
auth = await spoofy.easy_auth(
        client_id='client_id',
        client_secret='client_secret',
        scope=('scope'),
        cache_file='tokens.json'
)
async with spoofy.Client(auth) as sp:
    print(await sp.get_me())
```
or:
```
auth = await spoofy.easy_auth(
        client_id='client_id',
        client_secret='client_secret',
        scope=('scope'),
        cache_file='tokens.json'
)
sp = spoofy.Client(auth)
print(await sp.get_me())
await sp.close_session()
```

### What has been edited?

- Added kwargs (to be able to set additional query/body parameters, for example custom market/country parameter) and additional args for several methods for more flexibility

### What has been fixed?

- Getting some old albums ([like this one](https://open.spotify.com/album/3r9KCuMpdi4jm4l4EjAG0M)) cause an "ValueError" error in "Album" class. This happened because this and some other old albums have 0000 release year in Spotify. 
Now if in setting release date happened "ValueError", release date setting as None object

I didn't update the documentation for these changes, because I never worked with it.