### PR TITLE
Audio analysis endpoint

### DIFF
--- a/asyncspotify/audioanalysis.py
+++ b/asyncspotify/audioanalysis.py
@@ -1,5 +1,5 @@
-from .utils	import convertToTimeDelta
 from .object import Object
+from datetime import timedelta
 
 class AudioAnalysis(Object):
 	'''
@@ -10,13 +10,42 @@ class AudioAnalysis(Object):
 
 	def __init__(self, client, data):
 		super().__init__(client, data)
-		# List of seconds fields in data
-		listOfFieldsToConvert = ['start','duration','offset_seconds','window_seconds','start_of_fade_out','loudness_max_time']
-		data = convertToTimeDelta(data, listOfFieldsToConvert)
-		self.bars = data.pop('bars')
+		# Create list of the dicts in data['bars'] with start and duration converted to timedelta objects
+		self.bars = [{
+			'start': timedelta(seconds=bar.pop('start')), 
+			'duration': timedelta(seconds=bar.pop('duration')), 
+			**bar} 
+			for bar in data['bars']
+		] 
+		self.beats = [{
+			'start': timedelta(seconds=beat.pop('start')), 
+			'duration': timedelta(seconds=beat.pop('duration')), 
+			**beat} 
+			for beat in data['beats']
+		] 
+		self.tatums = [{
+			'start': timedelta(seconds=tatum.pop('start')), 
+			'duration': timedelta(seconds=tatum.pop('duration')), 
+			**tatum} 
+			for tatum in data['tatums']
+		] 
+		self.sections = [{
+			'start': timedelta(seconds=section.pop('start')), 
+			'duration': timedelta(seconds=section.pop('duration')), 
+			**section} 
+			for section in data['sections']
+		] 
+		self.segments = [{
+			'start': timedelta(seconds=segment.pop('start')), 
+			'duration': timedelta(seconds=segment.pop('duration')), 
+			'loudness_max_time': timedelta(seconds=segment.pop('loudness_max_time')),
+			**segment} 
+			for segment in data['segments']
+		] 
 		self.track = data.pop('track')
-		self.beats = data.pop('beats')
-		self.tatums = data.pop('tatums')
-		self.sections = data.pop('sections')
-		self.segments = data.pop('segments')
-
+		self.track['duration'] = timedelta(seconds=self.track['duration'])
+		self.track["offset_seconds"] = timedelta(seconds=self.track['offset_seconds'])
+		self.track["window_seconds"] = timedelta(seconds=self.track['window_seconds'])
+		self.track["end_of_fade_in"] = timedelta(seconds=self.track['end_of_fade_in'])
+		self.track["start_of_fade_out"] = timedelta(seconds=self.track['start_of_fade_out'])
+	

--- a/asyncspotify/audioanalysis.py
+++ b/asyncspotify/audioanalysis.py
@@ -1,0 +1,14 @@
+from datetime import timedelta
+from .object import Object
+
+class AudioAnalysis(Object):
+	_type = 'audio_analysis'
+
+	def __init__(self, client, data):
+		super().__init__(client, data)
+		self.bars = data.pop('bars')
+		self.track = data.pop('track')
+		self.beats = data.pop('beats')
+		self.tatums = data.pop('tatums')
+		self.sections = data.pop('sections')
+		self.segments = data.pop('segments')

--- a/asyncspotify/audioanalysis.py
+++ b/asyncspotify/audioanalysis.py
@@ -1,14 +1,22 @@
-from datetime import timedelta
+from .utils	import convertToTimeDelta
 from .object import Object
 
 class AudioAnalysis(Object):
+	'''
+	Class for Audio Analysis results from the Spotify API.
+    
+	'''
 	_type = 'audio_analysis'
 
 	def __init__(self, client, data):
 		super().__init__(client, data)
+		# List of seconds fields in data
+		listOfFieldsToConvert = ['start','duration','offset_seconds','window_seconds','start_of_fade_out','loudness_max_time']
+		data = convertToTimeDelta(data, listOfFieldsToConvert)
 		self.bars = data.pop('bars')
 		self.track = data.pop('track')
 		self.beats = data.pop('beats')
 		self.tatums = data.pop('tatums')
 		self.sections = data.pop('sections')
 		self.segments = data.pop('segments')
+

--- a/asyncspotify/client.py
+++ b/asyncspotify/client.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from .album import FullAlbum, SimpleAlbum
 from .artist import FullArtist, SimpleArtist
 from .audiofeatures import AudioFeatures
+from .audioanalysis import AudioAnalysis
 from .device import Device
 from .exceptions import NotFound, SpotifyException
 from .http import HTTP
@@ -597,6 +598,23 @@ class Client:
 			return None
 
 		return AudioFeatures(self, data)
+
+	async def get_audio_analysis(self, track) -> Optional[AudioAnalysis]:
+		'''
+		Get 'Audio Analysis' of a track.
+
+		:param track: :class:`Track` instance or Spotify ID.
+		:return: :class:`AudioAnalysis`
+		'''
+
+		track = get_id(track)
+
+		try:
+			data = await self.http.get_audio_analysis(track)
+		except NotFound:
+			return None
+
+		return AudioAnalysis(self, data)
 
 	async def get_artist(self, artist_id) -> Optional[FullArtist]:
 		'''

--- a/asyncspotify/http.py
+++ b/asyncspotify/http.py
@@ -243,6 +243,10 @@ class HTTP:
 		r = Route('GET', 'audio-features/{0}'.format(track_id))
 		return await self.request(r)
 
+	async def get_audio_analysis(self, track_id):
+		r = Route('GET', 'audio-analysis/{0}'.format(track_id))
+		return await self.request(r)
+
 	async def get_artist(self, artist_id):
 		r = Route('GET', 'artists/{0}'.format(artist_id))
 		return await self.request(r)

--- a/asyncspotify/track.py
+++ b/asyncspotify/track.py
@@ -38,12 +38,11 @@ class _BaseTrack(Object, ExternalURLMixin, ArtistMixin):
 		
 	async def get_audio_analysis(self):
 		'''
-		Get 'Audio Features' of the track.
+		Get 'Audio Analysis' of the track.
 		
 		:param track: :class:`Track` instance or Spotify ID of track.
-		:return: :class:`AudioFeatures`
+		:return: :class:`AudioAnalysis`
 		'''
-
 		return await self._client.get_audio_analysis(self.id)
 
 class SimpleTrack(_BaseTrack):

--- a/asyncspotify/track.py
+++ b/asyncspotify/track.py
@@ -35,7 +35,16 @@ class _BaseTrack(Object, ExternalURLMixin, ArtistMixin):
 		'''
 
 		return await self._client.get_audio_features(self.id)
+		
+	async def get_audio_analysis(self):
+		'''
+		Get 'Audio Features' of the track.
+		
+		:param track: :class:`Track` instance or Spotify ID of track.
+		:return: :class:`AudioFeatures`
+		'''
 
+		return await self._client.get_audio_analysis(self.id)
 
 class SimpleTrack(_BaseTrack):
 	'''

--- a/asyncspotify/utils.py
+++ b/asyncspotify/utils.py
@@ -45,28 +45,3 @@ def subslice(iter, step):
 
 	if group:
 		yield group
-
-def convertToTimeDelta(data, listOfFieldsToConvert):
-	'''
-	Function to convert fields into timedelta objects
-
-	:parm data: Dictionary containing lists of dicts or dicts or a mix of both
-	:parm listOfFieldsToConvert: List of the fields that need to be converted into time delta objects 
-	'''
-	# Loop through primary keys in data
-	for item in data:
-		# Applies to all the primary keys except track. These only have start and duration keys so this might be able to be simplified
-		if type(data[item]) == list:
-			for field in listOfFieldsToConvert:
-				# Check if the field exists in the list
-				if data[item][0].get(field, None) != None:
-					# Loop through each item in list, setting the field to a timedelta object
-					for i in data[item]:
-						i[field] = timedelta(seconds=i[field])
-		elif type(data[item]) == dict:
-			# Ignore the meta field
-			if item != 'meta':
-				for field in listOfFieldsToConvert:
-					if data[item].get(field, None) != None:
-						data[item][field] = timedelta(seconds=data[item][field])
-	return data

--- a/asyncspotify/utils.py
+++ b/asyncspotify/utils.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 def get(items, **kwargs):
 	'''
 	Get an item from a list of items.
@@ -43,3 +45,28 @@ def subslice(iter, step):
 
 	if group:
 		yield group
+
+def convertToTimeDelta(data, listOfFieldsToConvert):
+	'''
+	Function to convert fields into timedelta objects
+
+	:parm data: Dictionary containing lists of dicts or dicts or a mix of both
+	:parm listOfFieldsToConvert: List of the fields that need to be converted into time delta objects 
+	'''
+	# Loop through primary keys in data
+	for item in data:
+		# Applies to all the primary keys except track. These only have start and duration keys so this might be able to be simplified
+		if type(data[item]) == list:
+			for field in listOfFieldsToConvert:
+				# Check if the field exists in the list
+				if data[item][0].get(field, None) != None:
+					# Loop through each item in list, setting the field to a timedelta object
+					for i in data[item]:
+						i[field] = timedelta(seconds=i[field])
+		elif type(data[item]) == dict:
+			# Ignore the meta field
+			if item != 'meta':
+				for field in listOfFieldsToConvert:
+					if data[item].get(field, None) != None:
+						data[item][field] = timedelta(seconds=data[item][field])
+	return data


### PR DESCRIPTION
Implementation of the audio analysis endpoint. Seconds fields are converted into timedelta objects to be consistent with other areas of the code, though this may be a bit over engineered for the purpose. Otherwise, the returned data is left much untouched.
Should fix Run1e/asyncspotify#9